### PR TITLE
Add NvidiaApp to GamePlatform

### DIFF
--- a/OmniConsole/Models/GamePlatform.cs
+++ b/OmniConsole/Models/GamePlatform.cs
@@ -8,6 +8,7 @@ namespace OmniConsole.Models
         SteamBigPicture,
         XboxApp,
         EpicGames,
-        ArmouryCrateSE
+        ArmouryCrateSE,
+        NvidiaApp
     }
 }


### PR DESCRIPTION
You know the Drill. Nvidia, AMD (And Intel?) are offering Game Launchers inside their GPU Control Apps. I just made an example with this .cs File so i don't had to open an "Issue". Would be extremely nice to see Support for it! Keep up the awesome Work!